### PR TITLE
Hotfix/1.6.1

### DIFF
--- a/app/Model/History.php
+++ b/app/Model/History.php
@@ -51,7 +51,7 @@ class History extends ProgramSpecificMongoModel
             'pending' => array(),
             'delivered' => array(),
             'ack' => array(),
-            'nack' => array(),
+            'nack' => array('failure-reason'),
             'no-credit' => array(),
             'no-credit-timeframe' => array(),
             'missing-data' => array('missing-data'),

--- a/app/View/ProgramHistory/index.ctp
+++ b/app/View/ProgramHistory/index.ctp
@@ -77,6 +77,9 @@
                     case 'failed':
                         $title = $history['History']['failure-reason'];
                         break;
+                    case 'nack':
+                        $title = $history['History']['failure-reason'];
+                        break;    
                     case 'forwarded':
                         $tmp=array();
                         foreach ($history['History']['forwards'] as $forward) {


### PR DESCRIPTION
Form the backend https://github.com/texttochange/vusion-backend/blob/develop/vusion/persist/history/history.py#L68

the failure-reason is already defined so i just used that.