### PR TITLE
show the exported file for participants and history

### DIFF
--- a/app/Controller/ProgramHistoryController.php
+++ b/app/Controller/ProgramHistoryController.php
@@ -134,7 +134,29 @@ class ProgramHistoryController extends BaseProgramSpecificController
         $this->response->send();
     }
     
-    
+    public function exported()
+    {
+        $programUrl = $this->programDetails['url'];
+        $programDirPath = WWW_ROOT . "files/programs/". $programUrl;
+        $exportedFiles = scandir($programDirPath);
+        $exportedHistoryFiles = array_filter($exportedFiles, function($var) { 
+            return strpos($var, 'history');});
+        $files = array();
+        foreach ($exportedHistoryFiles as $file) {
+            $fileFullName = $programDirPath . DS . $file;
+            $files[] = array(
+                'name' =>  $file,
+                'size' => filesize($fileFullName),
+                'created' => filemtime($fileFullName));
+        }
+        $created = array();
+        foreach ($files as $key => $row) {
+            $created[$key] = $row['created'];
+        }
+        array_multisort($created, SORT_DESC, $files);
+        $this->set(compact('files'));
+    }
+
     public function export()
     {
         $programUrl = $this->params['program'];

--- a/app/Controller/ProgramHistoryController.php
+++ b/app/Controller/ProgramHistoryController.php
@@ -133,12 +133,13 @@ class ProgramHistoryController extends BaseProgramSpecificController
         $this->response->header('Content-Disposition: attachment; filename="' . basename($fileFullPath) . '"');
         $this->response->send();
     }
-    
+
+
     public function exported()
     {
-        $programUrl = $this->programDetails['url'];
-        $programDirPath = WWW_ROOT . "files/programs/". $programUrl;
-        $exportedFiles = scandir($programDirPath);
+        $programUrl           = $this->programDetails['url'];
+        $programDirPath       = WWW_ROOT . "files/programs/". $programUrl;
+        $exportedFiles        = scandir($programDirPath);
         $exportedHistoryFiles = array_filter($exportedFiles, function($var) { 
             return strpos($var, 'history');});
         $files = array();
@@ -156,6 +157,7 @@ class ProgramHistoryController extends BaseProgramSpecificController
         array_multisort($created, SORT_DESC, $files);
         $this->set(compact('files'));
     }
+
 
     public function export()
     {

--- a/app/Controller/ProgramParticipantsController.php
+++ b/app/Controller/ProgramParticipantsController.php
@@ -225,12 +225,13 @@ class ProgramParticipantsController extends BaseProgramSpecificController
         }
         $this->redirect($redirectUrl);
     }
-    
+
+
     public function exported()
     {
-        $programUrl = $this->programDetails['url'];
-        $programDirPath = WWW_ROOT . "files/programs/". $programUrl;
-        $exportedFiles = scandir($programDirPath);
+        $programUrl               = $this->programDetails['url'];
+        $programDirPath           = WWW_ROOT . "files/programs/". $programUrl;
+        $exportedFiles            = scandir($programDirPath);
         $exportedParticipantFiles = array_filter($exportedFiles, function($var) { 
             return strpos($var, 'participants');});
         $files = array();

--- a/app/Controller/ProgramParticipantsController.php
+++ b/app/Controller/ProgramParticipantsController.php
@@ -226,6 +226,29 @@ class ProgramParticipantsController extends BaseProgramSpecificController
         $this->redirect($redirectUrl);
     }
     
+    public function exported()
+    {
+        $programUrl = $this->programDetails['url'];
+        $programDirPath = WWW_ROOT . "files/programs/". $programUrl;
+        $exportedFiles = scandir($programDirPath);
+        $exportedParticipantFiles = array_filter($exportedFiles, function($var) { 
+            return strpos($var, 'participants');});
+        $files = array();
+        foreach ($exportedParticipantFiles as $file) {
+            $fileFullName = $programDirPath . DS . $file;
+            $files[] = array(
+                'name' =>  $file,
+                'size' => filesize($fileFullName),
+                'created' => filemtime($fileFullName));
+        }
+        $created = array();
+        foreach ($files as $key => $row) {
+            $created[$key] = $row['created'];
+        }
+        array_multisort($created, SORT_DESC, $files);
+        $this->set(compact('files'));
+    }
+
     
     public function export() 
     {

--- a/app/Lib/TestHelper.php
+++ b/app/Lib/TestHelper.php
@@ -4,11 +4,11 @@ class TestHelper
 {
 
 
-	public static function deleteAllProgramFiles($programUrl) 
+    public static function deleteAllProgramFiles($programUrl)
     {
         $files = glob(WWW_ROOT . "files/programs/$programUrl/*"); // get all file names
-        foreach($files as $file){ // iterate files
-            if(is_file($file)) {
+        foreach ($files as $file) { // iterate files
+            if (is_file($file)) {
                 unlink($file); // delete file
             }
         }

--- a/app/Lib/TestHelper.php
+++ b/app/Lib/TestHelper.php
@@ -1,0 +1,18 @@
+<?php
+
+class TestHelper 
+{
+
+
+	public static function deleteAllProgramFiles($programUrl) 
+    {
+        $files = glob(WWW_ROOT . "files/programs/$programUrl/*"); // get all file names
+        foreach($files as $file){ // iterate files
+            if(is_file($file)) {
+                unlink($file); // delete file
+            }
+        }
+    }
+
+
+}

--- a/app/Test/Case/Controller/ProgramHistoryControllerTest.php
+++ b/app/Test/Case/Controller/ProgramHistoryControllerTest.php
@@ -2,6 +2,7 @@
 App::uses('ProgramHistoryController', 'Controller');
 App::uses('Program', 'Model');
 App::uses('ScriptMaker', 'Lib');
+App::uses('TestHelper', 'Lib');
 App::uses('ProgramSpecificMongoModel', 'Model');
 
 
@@ -54,6 +55,7 @@ class ProgramHistoryControllerTestCase extends ControllerTestCase
     {
         $this->History->deleteAll(true, false);
         $this->ProgramSetting->deleteAll(true, false);
+        TestHelper::deleteAllProgramFiles('testurl');
     }    
 
 
@@ -417,5 +419,25 @@ class ProgramHistoryControllerTestCase extends ControllerTestCase
         $this->assertEqual($this->vars['paginationCount'], 0);
     }
 
+
+    public function testExported()
+    {
+        $this->mockProgramAccess();
+
+        copy(TESTS . 'files/exported_history.csv', 
+            WWW_ROOT . 'files/programs/testurl/Program_history_2014-01-01_10-10-10.csv');
+        sleep(1);  // to get a different in the system creating date
+        copy(TESTS . 'files/exported_history.csv', 
+            WWW_ROOT . 'files/programs/testurl/Program_history_2014-01-02_10-10-10.csv');
+        copy(TESTS . 'files/exported_participants.csv', 
+            WWW_ROOT . 'files/programs/testurl/Program_participants_2014-01-02_10-10-10.csv');
+
+
+        $this->testAction("/testurl/programHistory/exported");
+        $files = $this->vars['files'];
+        $this->assertEqual(2, count($files));
+        $this->assertEqual($files[0]['name'], 'Program_history_2014-01-02_10-10-10.csv');
+        $this->assertEqual($files[1]['name'], 'Program_history_2014-01-01_10-10-10.csv');
+    }
 
 }

--- a/app/Test/Case/Controller/ProgramParticipantsControllerTest.php
+++ b/app/Test/Case/Controller/ProgramParticipantsControllerTest.php
@@ -1532,7 +1532,7 @@ class ProgramParticipantsControllerTestCase extends ControllerTestCase
    }
 
 
-     public function testExported()
+    public function testExported()
     {
         $this->mockProgramAccess();
 

--- a/app/Test/Case/Controller/ProgramParticipantsControllerTest.php
+++ b/app/Test/Case/Controller/ProgramParticipantsControllerTest.php
@@ -2,6 +2,7 @@
 App::uses('ProgramParticipantsController', 'Controller');
 App::uses('Schedule', 'Model');
 App::uses('ScriptMaker', 'Lib');
+App::uses('TestHelper', 'Lib');
 App::uses('Dialogue', 'Model');
 App::uses('Participant', 'Model');
 App::uses('History', 'Model');
@@ -66,6 +67,7 @@ class ProgramParticipantsControllerTestCase extends ControllerTestCase
         $this->ProgramSetting->deleteAll(true,false);
         $this->History->deleteAll(true, false);
         $this->Dialogue->deleteAll(true, false);
+        TestHelper::deleteAllProgramFiles('testurl');
     }
 
 
@@ -1529,5 +1531,25 @@ class ProgramParticipantsControllerTestCase extends ControllerTestCase
         $this->assertEquals($this->vars['paginationCount'], 0);
    }
 
+
+     public function testExported()
+    {
+        $this->mockProgramAccess();
+
+        copy(TESTS . 'files/exported_participants.csv', 
+            WWW_ROOT . 'files/programs/testurl/Program_participants_2014-01-01_10-10-10.csv');
+        sleep(1);  // to get a different in the system creating date
+        copy(TESTS . 'files/exported_participants.csv', 
+            WWW_ROOT . 'files/programs/testurl/Program_participants_2014-01-02_10-10-10.csv');
+        copy(TESTS . 'files/exported_history.csv', 
+            WWW_ROOT . 'files/programs/testurl/Program_history_2014-01-02_10-10-10.csv');
+
+
+        $this->testAction("/testurl/programHistory/exported");
+        $files = $this->vars['files'];
+        $this->assertEqual(2, count($files));
+        $this->assertEqual($files[0]['name'], 'Program_participants_2014-01-02_10-10-10.csv');
+        $this->assertEqual($files[1]['name'], 'Program_participants_2014-01-01_10-10-10.csv');
+    }
     
 }

--- a/app/View/Elements/navigation_menu.ctp
+++ b/app/View/Elements/navigation_menu.ctp
@@ -225,18 +225,28 @@
         <ul>
             <li>
                 <?php 
-                     echo $this->AclLink->generateLink(__('Add Participants'),$programDetails['url'],'programParticipants','add');
+                     echo $this->AclLink->generateLink(__('Add'),$programDetails['url'],'programParticipants','add');
                 ?>
             </li>
-		    <li>
-		        <?php
-		             echo $this->AclLink->generateLink(__('Import Participants'),$programDetails['url'],'programParticipants','import');
-		        ?>
-		    </li>
+		        <li>
+		            <?php
+		                echo $this->AclLink->generateLink(__('Import'),$programDetails['url'],'programParticipants','import');
+		            ?>
+		        </li>
+            <li>
+                <?php
+                    echo $this->AclLink->generateLink(__('Exported File(s)'),$programDetails['url'],'programParticipants','exported');
+                ?>
+            </li>
         </ul>
     </li>
     <li>
         <?php echo $this->AclLink->generateLink(__('History'),$programDetails['url'],'programHistory'); ?>        
+        <ul>
+          <li>
+            <?php echo $this->AclLink->generateLink(__('Exported File(s)'),$programDetails['url'],'programHistory','exported'); ?>
+          </li>
+        </ul>
     </li>
     <li>
         <?php

--- a/app/View/Elements/navigation_menu.ctp
+++ b/app/View/Elements/navigation_menu.ctp
@@ -191,7 +191,7 @@
                        array('ellipsis' => '...',
                            'exact' => true
                            ));      
-		
+      
                    
                    echo $this->AclLink->generateLink($predefinedMessageLinkName,
                        $programDetails['url'], 'programPredefinedMessages', 'edit', $predefinedMessage['PredefinedMessage']['_id']);
@@ -228,11 +228,11 @@
                      echo $this->AclLink->generateLink(__('Add'),$programDetails['url'],'programParticipants','add');
                 ?>
             </li>
-		        <li>
-		            <?php
-		                echo $this->AclLink->generateLink(__('Import'),$programDetails['url'],'programParticipants','import');
-		            ?>
-		        </li>
+              <li>
+                  <?php
+                      echo $this->AclLink->generateLink(__('Import'),$programDetails['url'],'programParticipants','import');
+                  ?>
+              </li>
             <li>
                 <?php
                     echo $this->AclLink->generateLink(__('Exported File(s)'),$programDetails['url'],'programParticipants','exported');

--- a/app/View/ProgramHistory/exported.ctp
+++ b/app/View/ProgramHistory/exported.ctp
@@ -1,0 +1,38 @@
+<div class="history index width-size">
+    <div>
+        <h3><?php echo __('Exported File of History'); ?></h3>
+        <ul class="ttc-actions">
+        <li></li>
+        </ul>
+    </div>
+    <div class="ttc-table-display-area" style="width:100%">
+    <div class="ttc-table-scrolling-area display-height-size">
+    <table class="participants" cellpadding="0" cellspacing="0">
+        <thead>
+            <tr>
+                <th class="file"><?php echo __('File Name'); ?></th>
+                <th class="size"><?php echo __('Size'); ?></th>
+                <th class="date"><?php echo __('Created'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if ($files == array()) { ?>
+            <tr>
+                <td colspan=2><?php echo __("No history export file found.") ?></td>
+            </tr>
+        <?php } else {?>   
+        <?php foreach ($files as $file): ?>
+            <tr>
+                <td>
+                    <a href="<?php echo $this->Html->url(array('program' => $programDetails['url'], 'action' => 'download', '?' => array('file' => $file['name'])));?>">
+                    <?php echo $file['name']; ?></td>
+                    </a>
+                <td><?php echo $this->Number->toReadableSize($file['size']); ?></td>
+                <td><?php 
+                echo $this->Time->niceShort($this->Time->convert($file['created'], $programDetails['settings']['timezone'])); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        <?php }; ?>
+        </tbody>
+    </table>
+</div>

--- a/app/View/ProgramParticipants/exported.ctp
+++ b/app/View/ProgramParticipants/exported.ctp
@@ -1,0 +1,38 @@
+<div class="participants index width-size">
+    <div>
+        <h3><?php echo __('Exported Files of Participants'); ?></h3>
+        <ul class="ttc-actions">
+        <li></li>
+        </ul>
+    </div>
+    <div class="ttc-table-display-area" style="width:100%">
+    <div class="ttc-table-scrolling-area display-height-size">
+    <table class="participants" cellpadding="0" cellspacing="0">
+        <thead>
+            <tr>
+                <th class="file"><?php echo __('File Name'); ?></th>
+                <th class="size"><?php echo __('Size'); ?></th>
+                <th class="date"><?php echo __('Created'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if ($files == array()) { ?>
+            <tr>
+                <td colspan=2><?php echo __("No participant export file found.") ?></td>
+            </tr>
+        <?php } else {?>   
+        <?php foreach ($files as $file): ?>
+            <tr>
+                <td>
+                    <a href="<?php echo $this->Html->url(array('program' => $programDetails['url'], 'action' => 'download', '?' => array('file' => $file['name'])));?>">
+                    <?php echo $file['name']; ?></td>
+                    </a>
+                <td><?php echo $this->Number->toReadableSize($file['size']); ?></td>
+                <td><?php 
+                echo $this->Time->niceShort($this->Time->convert($file['created'], $programDetails['settings']['timezone'])); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        <?php }; ?>
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
need to sync the ACL

Allow to see and download all files that have been exported in an program. To access, see 
- NavMenu>Participants>Exported File(s)
- NavMenu>History>Exported File(s)

This is the first leg to fix the export of big file.