### PR TITLE
remove usage of MongoRegex in order to be serializable to the backend

### DIFF
--- a/app/Model/History.php
+++ b/app/Model/History.php
@@ -406,10 +406,10 @@ class History extends ProgramSpecificMongoModel
                 if ($filterParam[2] == 'equal-to') {
                     $condition['participant-phone'] = $filterParam[3];                   
                 } elseif ($filterParam[2] == 'start-with') {
-                    $condition['participant-phone'] = new MongoRegex("/^\\".$filterParam[3]."/");
+                    $condition['participant-phone'] = array('$regex' => "^\\".$filterParam[3]);
                 } elseif ($filterParam[2] == 'start-with-any') {
                     $phoneNumbers = explode(",", str_replace(" ", "", $filterParam[3]));
-                    $condition = $this->_createOrRegexQuery('participant-phone', $phoneNumbers, "\\", "/"); 
+                    $condition = $this->_createOrRegexQuery('participant-phone', $phoneNumbers, "\\", '', 'i'); 
                 }
             } else {
                 $condition['participant-phone'] = '';
@@ -419,12 +419,12 @@ class History extends ProgramSpecificMongoModel
                 if ($filterParam[2] == 'equal-to') {
                     $condition['message-content'] = $filterParam[3];
                 } elseif ($filterParam[2] == 'contain') {
-                    $condition['message-content'] = new MongoRegex("/".$filterParam[3]."/i");
+                    $condition['message-content'] = array('$regex' => $filterParam[3], '$options' => 'i');
                 } elseif ($filterParam[2] == 'has-keyword') {
-                    $condition['message-content'] = new MongoRegex("/^".$filterParam[3]."($| )/i");
+                    $condition['message-content'] = array('$regex' => "^".$filterParam[3]."($| )", '$options' => 'i');
                 } elseif ($filterParam[2] == 'has-keyword-any') {
                     $keywords  = explode(",", str_replace(" ", "", $filterParam[3]));
-                    $condition = $this->_createOrRegexQuery('message-content', $keywords, null, "($| )/i");
+                    $condition = $this->_createOrRegexQuery('message-content', $keywords, null, '($| )', 'i');
                 }
             } else {
                 $condition['message-content'] = '';
@@ -494,18 +494,18 @@ class History extends ProgramSpecificMongoModel
     } 
     
     
-    protected function _createOrRegexQuery($field, $choices, $prefix=null, $suffix=null) 
+    protected function _createOrRegexQuery($field, $choices, $prefix=null, $suffix=null, $options='') 
     {
         $query = array();
         if (count($choices) > 1) {
             $or = array();
             foreach ($choices as $choice) {
-                $regex = new MongoRegex("/^".$prefix.$choice.$suffix);
+                $regex = array( '$regex' => '^'.$prefix.$choice.$suffix, '$options' => $options);
                 $or[]  = array($field => $regex);
             }
             $query['$or'] = $or;
         } else {
-            $query[$field] = new MongoRegex("/^".$prefix.$choices[0].$suffix);
+            $query[$field] = array( '$regex' => '^'.$prefix.$choices[0].$suffix, '$options' => $options);
         }
         return $query;
     }

--- a/app/Model/Participant.php
+++ b/app/Model/Participant.php
@@ -962,16 +962,16 @@ class Participant extends ProgramSpecificMongoModel
                         if (count($phoneNumbers) > 1) {
                             $or = array();
                             foreach ($phoneNumbers as $phoneNumber) {
-                                $regex = new MongoRegex("/^\\".$phoneNumber."/");
+                                $regex = array('$regex' => "^\\".$phoneNumber);
                                 $or[] = array('phone' => $regex);
                             }
                             $condition['$or'] = $or;
                         } else {
-                            $condition['phone'] = new MongoRegex("/^\\".$phoneNumbers[0]."/");
+                            $condition['phone'] = array('$regex' => "^\\".$phoneNumbers[0]);
                         }
                     } 
                 } elseif ($filterParam[2] == 'start-with') {
-                    $condition['phone'] = new MongoRegex("/^\\".$filterParam[3]."/"); 
+                    $condition['phone'] = array('$regex' => "^\\".$filterParam[3]); 
                 } elseif ($filterParam[2] == 'equal-to') {
                     $condition['phone'] = $filterParam[3];        
                 }

--- a/app/Model/UnmatchableReply.php
+++ b/app/Model/UnmatchableReply.php
@@ -136,12 +136,12 @@ class UnmatchableReply extends MongoModel
         if ($filterParam[1] == 'country') {
             $countryPrefix = $this->countriesByPrefixes[$filterParam[3]];
             if ($filterParam[2] == 'is') {
-                $condition['participant-phone'] = new MongoRegex("/^(\\+)?".$countryPrefix."/");
+                $condition['participant-phone'] = array('$regex' => "^(\\+)?".$countryPrefix);
             }
         } elseif ($filterParam[1] == 'shortcode') {
             if ($filterParam[2] == 'is') {
                 $condition['$or'] = array(
-                    array('participant-phone' => new MongoRegex("/\\d*-".$filterParam[3]."$/")),
+                    array('participant-phone' => array('$regex' => "\\d*-".$filterParam[3]."$")),
                     array('to' => $filterParam[3]));
             }
         } elseif ($filterParam[1] == 'date') {
@@ -154,19 +154,19 @@ class UnmatchableReply extends MongoModel
             if ($filterParam[2] == 'equal-to') {
                 $condition['participant-phone'] = $filterParam[3];                   
             } elseif ($filterParam[2] == 'start-with') {
-                $condition['participant-phone'] = new MongoRegex("/^\\".$filterParam[3]."/");
+                $condition['participant-phone'] = array('$regex' => "^\\".$filterParam[3]);
             } elseif ($filterParam[2] == 'start-with-any') {
                 $phoneNumbers = explode(",", str_replace(" ", "", $filterParam[3]));
                 if ($phoneNumbers) {
                     if (count($phoneNumbers) > 1) {
                         $or = array();
                         foreach ($phoneNumbers as $phoneNumber) {
-                            $regex = new MongoRegex("/^\\".$phoneNumber."/");
+                            $regex = array('$regex' => "^\\".$phoneNumber);
                             $or[] = array('participant-phone' => $regex);
                         }
                         $condition['$or'] = $or;
                     } else {
-                        $condition['participant-phone'] = new MongoRegex("/^\\".$phoneNumbers[0]."/");
+                        $condition['participant-phone'] = array('$regex' => "^\\".$phoneNumbers[0]);
                     }
                 }   
             }
@@ -174,15 +174,15 @@ class UnmatchableReply extends MongoModel
             if ($filterParam[2] == 'equal-to') {
                 $condition['to'] = $filterParam[3];                   
             } elseif ($filterParam[2] == 'start-with') {
-                $condition['to'] = new MongoRegex("/^\\".$filterParam[3]."/");
+                $condition['to'] = array('$regex' => "^\\".$filterParam[3]);
             } 
         } elseif ($filterParam[1] == 'message-content') {
             if ($filterParam[2] == 'equal-to') {
                 $condition['message-content'] = $filterParam[3];
             } elseif ($filterParam[2] == 'contain') {
-                $condition['message-content'] = new MongoRegex("/".$filterParam[3]."/i");
+                $condition['message-content'] = array('$regex' => $filterParam[3], '$options' => 'i');
             } elseif ($filterParam[2] == 'has-keyword') {
-                $condition['message-content'] = new MongoRegex("/^".$filterParam[3]."($| )/i");
+                $condition['message-content'] = array('$regex' => "^".$filterParam[3]."($| )", '$options' => 'i');
             }
         } 
         

--- a/app/Test/Case/Model/HistoryTest.php
+++ b/app/Test/Case/Model/HistoryTest.php
@@ -196,7 +196,7 @@ class HistoryTestCase extends CakeTestCase
             3 => '+255'); 
         $this->assertEqual(
             $this->History->fromFilterToQueryCondition($filterParam),
-            array('participant-phone' => new MongoRegex('/^\\+255/')));
+            array('participant-phone' => array('$regex' => '^\\+255')));
         
         $filterParam = array(
             1 => 'participant-phone', 
@@ -213,8 +213,8 @@ class HistoryTestCase extends CakeTestCase
         $this->assertEqual(
             $this->History->fromFilterToQueryCondition($filterParam),
             array('$or' => array(
-                array('participant-phone' => new MongoRegex('/^\\+255/')),
-                array('participant-phone' => new MongoRegex('/^\\+256/')))));
+                array('participant-phone' => array('$regex' => '^\\+255', '$options' => 'i')),
+                array('participant-phone' => array('$regex' => '^\\+256', '$options' => 'i')))));
     }
     
     
@@ -234,7 +234,7 @@ class HistoryTestCase extends CakeTestCase
             3 => 'content'); 
         $this->assertEqual(
             $this->History->fromFilterToQueryCondition($filterParam),
-            array('message-content' => new MongoRegex('/content/i')));
+            array('message-content' => array('$regex' => 'content', '$options' => 'i')));
         
         $filterParam = array(
             1 => 'message-content', 
@@ -242,7 +242,7 @@ class HistoryTestCase extends CakeTestCase
             3 => 'keyword'); 
         $this->assertEqual(
             $this->History->fromFilterToQueryCondition($filterParam),
-            array('message-content' => new MongoRegex('/^keyword($| )/i')));
+            array('message-content' => array('$regex' => '^keyword($| )', '$options' => 'i')));
         
         $filterParam = array(
             1 => 'message-content', 
@@ -252,8 +252,8 @@ class HistoryTestCase extends CakeTestCase
             $this->History->fromFilterToQueryCondition($filterParam),
             array(
                 '$or' => array(
-                    array('message-content' => new MongoRegex('/^keyword1($| )/i')),
-                    array('message-content' => new MongoRegex('/^keyword2($| )/i'))
+                    array('message-content' => array('$regex' => '^keyword1($| )', '$options' => 'i')),
+                    array('message-content' => array('$regex' => '^keyword2($| )', '$options' => 'i'))
                     ))
             );
     }

--- a/app/Test/Case/Model/ParticipantTest.php
+++ b/app/Test/Case/Model/ParticipantTest.php
@@ -1115,7 +1115,7 @@ class ParticipantTestCase extends CakeTestCase
             3 => "+255");
         $this->assertEqual(
             $this->Participant->fromFilterToQueryCondition($filter),
-            array("phone" => new MongoRegex("/^\\+255/")));
+            array("phone" => array('$regex' => "^\\+255")));
         
         $filter = array(
             1 => 'phone', 
@@ -1125,8 +1125,8 @@ class ParticipantTestCase extends CakeTestCase
             $this->Participant->fromFilterToQueryCondition($filter),
             array('$or' => 
                 array(
-                    array("phone" => new MongoRegex("/^\\+255/")),
-                    array("phone" => new MongoRegex("/^\\+256/"))))
+                    array("phone" => array('$regex' => "^\\+255")),
+                    array("phone" => array('$regex' => "^\\+256"))))
             );
     }
     

--- a/app/Test/Case/Model/UnmatchableReplyTest.php
+++ b/app/Test/Case/Model/UnmatchableReplyTest.php
@@ -30,7 +30,7 @@ class UnmatchableReplyTestCase extends CakeTestCase
             3 => '+255'); 
         $this->assertEqual(
             $this->UnmatchableReply->fromFilterToQueryCondition($filterParam),
-            array('participant-phone' => new MongoRegex('/^\\+255/')));
+            array('participant-phone' => array('$regex' => '^\\+255')));
         
         $filterParam = array(
             1 => 'from-phone', 
@@ -48,8 +48,8 @@ class UnmatchableReplyTestCase extends CakeTestCase
         $this->assertEqual(
             $this->UnmatchableReply->fromFilterToQueryCondition($filterParam),
             array('$or' => array(
-                array('participant-phone' => new MongoRegex('/^\\+255/')),
-                array('participant-phone' => new MongoRegex('/^\\+256/'))
+                array('participant-phone' => array('$regex' => '^\\+255')),
+                array('participant-phone' => array('$regex' => '^\\+256'))
                 ))
             );
         
@@ -64,7 +64,7 @@ class UnmatchableReplyTestCase extends CakeTestCase
             3 => '+255'); 
         $this->assertEqual(
             $this->UnmatchableReply->fromFilterToQueryCondition($filterParam),
-            array('to' => new MongoRegex('/^\\+255/')));
+            array('to' => array('$regex' => '^\\+255')));
         
         $filterParam = array(
             1 => 'to-phone', 
@@ -84,7 +84,7 @@ class UnmatchableReplyTestCase extends CakeTestCase
             3 => 'Uganda');
         $this->assertEqual(
             $this->UnmatchableReply->fromFilterToQueryCondition($filterParam),
-            array('participant-phone' => new MongoRegex('/^(\\+)?256/')));
+            array('participant-phone' => array('$regex' => '^(\\+)?256')));
     }
     
     public function testfromFilterToQueryCondition_shortcode()
@@ -96,7 +96,7 @@ class UnmatchableReplyTestCase extends CakeTestCase
         $this->assertEqual(
             $this->UnmatchableReply->fromFilterToQueryCondition($filterParam),
             array('$or' => array(
-                array('participant-phone' => new MongoRegex('/\\d*-8181$/')),
+                array('participant-phone' => array('$regex' => '\\d*-8181$')),
                 array('to' => '8181')))
             );
     }
@@ -137,7 +137,7 @@ class UnmatchableReplyTestCase extends CakeTestCase
             3 => 'content'); 
         $this->assertEqual(
             $this->UnmatchableReply->fromFilterToQueryCondition($filterParam),
-            array('message-content' => new MongoRegex('/content/i')));
+            array('message-content' => array('$regex' => 'content', '$options' => 'i')));
         
         $filterParam = array(
             1 => 'message-content', 
@@ -145,7 +145,7 @@ class UnmatchableReplyTestCase extends CakeTestCase
             3 => 'keyword'); 
         $this->assertEqual(
             $this->UnmatchableReply->fromFilterToQueryCondition($filterParam),
-            array('message-content' => new MongoRegex('/^keyword($| )/i')));
+            array('message-content' => array('$regex' => '^keyword($| )', '$options' => 'i')));
     }
     
     


### PR DESCRIPTION
The MongoRegex object on the PHP side is not well serialisable to be reused on the backend side.   