### PR TITLE
fix not export simulated participant mongo query

### DIFF
--- a/app/Controller/ProgramParticipantsController.php
+++ b/app/Controller/ProgramParticipantsController.php
@@ -268,7 +268,9 @@ class ProgramParticipantsController extends BaseProgramSpecificController
         
         $conditions = $this->Filter->getConditions(
             $this->Participant,
-            array('simulate' => false),
+            array('$or' => array(
+                array('simulate' => false),
+                array('simulate' => array('$exists' => false)))),
             array('Schedule' => $this->Schedule),
             false);
         

--- a/app/Test/Case/Controller/ProgramParticipantsControllerTest.php
+++ b/app/Test/Case/Controller/ProgramParticipantsControllerTest.php
@@ -1415,7 +1415,9 @@ class ProgramParticipantsControllerTestCase extends ControllerTestCase
     public function testExport()
     {
         $participants = $this->mockProgramAccess();
-        $expectedCondition = array('simulate' => false);
+        $expectedCondition = array('$or' => array(
+            array('simulate' => false),
+            array('simulate' => array('$exists' => false))));
         $participants
         ->expects($this->once())
         ->method('_notifyBackendExport')


### PR DESCRIPTION
- [x] Smock test that participants created before the simulator are also exported.